### PR TITLE
テンプレートの置換する変数にprefixとsuffixを追加

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,9 @@ jobs:
       - name: update casks
         run: |
           cat template/casks/${{ inputs.cask }}.rb \
-            | sed 's/CASK_VERSION/${{ inputs.version }}/g' \
-            | sed 's/CASK_SHA256/${{ inputs.sha256 }}/g' \
-            | sed 's/CASK_SHA256_INTEL/${{ inputs.sha256_intel }}/g'> Casks/${{ inputs.cask }}.rb
+            | sed 's/__CASK_VERSION__/${{ inputs.version }}/g' \
+            | sed 's/__CASK_SHA256__/${{ inputs.sha256 }}/g' \
+            | sed 's/__CASK_SHA256_INTEL__/${{ inputs.sha256_intel }}/g'> Casks/${{ inputs.cask }}.rb
       - name: commit
         run: |
           git add .

--- a/template/casks/amethyst.rb
+++ b/template/casks/amethyst.rb
@@ -1,13 +1,13 @@
 cask "amethyst" do
-  version "CASK_VERSION"
+  version "__CASK_VERSION__"
 
   on_arm do
     arch "mac"
-    sha256 "CASK_SHA256"
+    sha256 "__CASK_SHA256__"
   end
   on_intel do
     arch "mac-intel"
-    sha256 "CASK_SHA256_INTEL"
+    sha256 "__CASK_SHA256_INTEL__"
   end
 
   url "https://github.com/walk8243/amethyst-electron/releases/download/#{version}/amethyst-#{version}-#{arch}.zip"


### PR DESCRIPTION
テンプレートの置換する変数にprefixとsuffixを追加して、 `sed` コマンドによる置換が完全一致になるようにする。